### PR TITLE
Win32 + Win64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 2.8)
+
 project (libkeccakc)
-include_directories(${CMAKE_SOURCE_DIR})
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 add_subdirectory(keccak)

--- a/keccak.h
+++ b/keccak.h
@@ -41,24 +41,29 @@ int sha3_224(register uint8_t* const restrict out,
              register const size_t outlen,
              register const uint8_t* const restrict in,
              register const size_t inlen);
-KECCAK_EXPORT int sha3_256(register uint8_t* const restrict out,
+KECCAK_EXPORT
+int sha3_256(register uint8_t* const restrict out,
              register const size_t outlen,
              register const uint8_t* const restrict in,
              register const size_t inlen);
-KECCAK_EXPORT int sha3_384(register uint8_t* const restrict out,
+KECCAK_EXPORT
+int sha3_384(register uint8_t* const restrict out,
              register const size_t outlen,
              register const uint8_t* const restrict in,
              register const size_t inlen);
-KECCAK_EXPORT int sha3_512(register uint8_t* const restrict out,
+KECCAK_EXPORT
+int sha3_512(register uint8_t* const restrict out,
              register const size_t outlen,
              register const uint8_t* const restrict in,
              register const size_t inlen);
 
-KECCAK_EXPORT int shake128(register uint8_t* const restrict out,
+KECCAK_EXPORT
+int shake128(register uint8_t* const restrict out,
              register const size_t outlen,
              register const uint8_t* const restrict in,
              register const size_t inlen);
-KECCAK_EXPORT int shake256(register uint8_t* const restrict out,
+KECCAK_EXPORT
+int shake256(register uint8_t* const restrict out,
              register const size_t outlen,
              register const uint8_t* const restrict in,
              register const size_t inlen);

--- a/keccak.h
+++ b/keccak.h
@@ -5,9 +5,23 @@
  */
 
 #include <stdlib.h>
-#include <stdalign.h>
 #include <stdint.h>
+
+#ifndef _MSC_VER
+#include <stdalign.h>
 #include <stdbool.h>
+#else
+#define restrict __restrict
+#if defined(keccak_EXPORTS)
+#define KECCAK_EXPORT __declspec(dllexport)
+#else
+#define KECCAK_EXPORT __declspec(dllexport)
+#endif
+#endif
+
+#ifndef KECCAK_EXPORT
+#define KECCAK_EXPORT
+#endif
 
 /* An opaque definition of the sponge structure.
  *
@@ -22,28 +36,29 @@ typedef struct keccak_sponge { uint64_t _OPAQUE[32]; } keccak_sponge;
 /********************************************************************
  * Simple interface to FIPS-202-defined functions.
  */
+KECCAK_EXPORT 
 int sha3_224(register uint8_t* const restrict out,
              register const size_t outlen,
              register const uint8_t* const restrict in,
              register const size_t inlen);
-int sha3_256(register uint8_t* const restrict out,
+KECCAK_EXPORT int sha3_256(register uint8_t* const restrict out,
              register const size_t outlen,
              register const uint8_t* const restrict in,
              register const size_t inlen);
-int sha3_384(register uint8_t* const restrict out,
+KECCAK_EXPORT int sha3_384(register uint8_t* const restrict out,
              register const size_t outlen,
              register const uint8_t* const restrict in,
              register const size_t inlen);
-int sha3_512(register uint8_t* const restrict out,
+KECCAK_EXPORT int sha3_512(register uint8_t* const restrict out,
              register const size_t outlen,
              register const uint8_t* const restrict in,
              register const size_t inlen);
 
-int shake128(register uint8_t* const restrict out,
+KECCAK_EXPORT int shake128(register uint8_t* const restrict out,
              register const size_t outlen,
              register const uint8_t* const restrict in,
              register const size_t inlen);
-int shake256(register uint8_t* const restrict out,
+KECCAK_EXPORT int shake256(register uint8_t* const restrict out,
              register const size_t outlen,
              register const uint8_t* const restrict in,
              register const size_t inlen);

--- a/keccak.h
+++ b/keccak.h
@@ -81,37 +81,49 @@ int shake256(register uint8_t* const restrict out,
  * output.)
  */
 // SHA3-224
+KECCAK_EXPORT
 int sha3_224_init(register keccak_sponge* const restrict sponge);
+KECCAK_EXPORT
 int sha3_224_update(register keccak_sponge* const restrict sponge,
                     register const uint8_t* const restrict in,
                     register const size_t inlen);
+KECCAK_EXPORT
 int sha3_224_digest(register keccak_sponge* const restrict sponge,
                     register uint8_t* const restrict out,
                     register const size_t outlen);
 
 // SHA3-256
+KECCAK_EXPORT
 int sha3_256_init(register keccak_sponge* const restrict sponge);
+KECCAK_EXPORT
 int sha3_256_update(register keccak_sponge* const restrict sponge,
                     register const uint8_t* const restrict in,
                     register const size_t inlen);
+KECCAK_EXPORT
 int sha3_256_digest(register keccak_sponge* const restrict sponge,
                     register uint8_t* const restrict out,
                     register const size_t outlen);
 
 // SHA3-384
+KECCAK_EXPORT
 int sha3_384_init(register keccak_sponge* const restrict sponge);
+KECCAK_EXPORT
 int sha3_384_update(register keccak_sponge* const restrict sponge,
                     register const uint8_t* const restrict in,
                     register const size_t inlen);
+KECCAK_EXPORT
 int sha3_384_digest(register keccak_sponge* const restrict sponge,
                     register uint8_t* const restrict out,
                     register const size_t outlen);
 
 // SHA3-512
+KECCAK_EXPORT
 int sha3_512_init(register keccak_sponge* const restrict sponge);
+KECCAK_EXPORT
 int sha3_512_update(register keccak_sponge* const restrict sponge,
                     register const uint8_t* const restrict in,
                     register const size_t inlen);
+KECCAK_EXPORT
 int sha3_512_digest(register keccak_sponge* const restrict sponge,
                     register uint8_t* const restrict out,
                     register const size_t outlen);
@@ -138,19 +150,25 @@ int sha3_512_digest(register keccak_sponge* const restrict sponge,
  */
 
 // SHAKE128
+KECCAK_EXPORT
 int shake128_init(register keccak_sponge* const restrict sponge);
+KECCAK_EXPORT
 int shake128_update(register keccak_sponge* const restrict sponge,
                     register const uint8_t* const restrict in,
                     register const size_t inlen);
+KECCAK_EXPORT
 int shake128_digest(register keccak_sponge* const restrict sponge,
                     register uint8_t* const restrict out,
                     register const size_t outlen);
 
 // SHAKE256
+KECCAK_EXPORT
 int shake256_init(register keccak_sponge* const restrict sponge);
+KECCAK_EXPORT
 int shake256_update(register keccak_sponge* const restrict sponge,
                     register const uint8_t* const restrict in,
                     register const size_t inlen);
+KECCAK_EXPORT
 int shake256_digest(register keccak_sponge* const restrict sponge,
                     register uint8_t* const restrict out,
                     register const size_t outlen);
@@ -170,11 +188,14 @@ int shake256_digest(register keccak_sponge* const restrict sponge,
  * from squeezing to absorbing; i.e., the permutation is never applied two
  * times in a row without either absorbing input or squeezing output.)
  */
+KECCAK_EXPORT
 int keccak_sponge_init(register keccak_sponge* const restrict sponge,
                        register const size_t rate);
+KECCAK_EXPORT
 int keccak_sponge_absorb(register keccak_sponge* const restrict sponge,
                          register const uint8_t* const restrict in,
                          register const size_t inlen);
+KECCAK_EXPORT
 int keccak_sponge_squeeze(register keccak_sponge* const restrict sponge,
                           register uint8_t* const restrict out,
                           register const size_t outlen);
@@ -186,4 +207,5 @@ int keccak_sponge_squeeze_xor(register keccak_sponge* const restrict sponge,
                               register uint8_t* const restrict out,
                               register const size_t outlen);
 */
+
 #endif  // KECCAK_H

--- a/keccak/CMakeLists.txt
+++ b/keccak/CMakeLists.txt
@@ -1,3 +1,40 @@
-add_library (keccak SHARED
-             fips202/sha3.c fips202/shake.c constructions/sponge.c
-             keccak/keccakf.c keccak/keccakf-1600/keccakf-opt64.c)
+if(CMAKE_COMPILER_IS_GNUCXX)
+	set(CMAKE_C_FLAGS "-std=c99")
+endif()
+
+list(APPEND src
+	"fips202/sha3.c"
+	"fips202/shake.c"
+	"constructions/sponge.c"
+	"keccak/keccakf.c"
+	"keccak/keccakf-1600/keccakf-opt64.c"
+	)
+
+list(APPEND public_hdrs
+	"../keccak.h"
+	)
+
+list(APPEND hdr
+	"config.h"
+	"keccak/keccak-1600.h"
+	"../libutil/libutil.h"
+	"constructions/sponge.h"
+	"fips202/flags.h"
+	"rte/check-impl.h"
+	"modes/hash/hash-impl.h"
+	"constructions/sponge-impl.h"
+	"utils/c11shim.h"
+	)
+
+set(libtype STATIC)
+
+add_library(libkeccak ${libtype} ${src} ${public_hdrs} ${hdr})
+
+set_target_properties(libkeccak PROPERTIES
+	INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/.."
+	INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/.."
+	COMPILE_DEFINITIONS NO_LIBUTIL
+	PUBLIC_HEADER "${public_hdrs}"
+#	VERSION 0.6.0
+	PREFIX ""
+	LIBFILENAME "libkeccak")

--- a/keccak/CMakeLists.txt
+++ b/keccak/CMakeLists.txt
@@ -1,3 +1,6 @@
+option(KECCAK_BUILD_TESTS "Build libkeccak test programs" ON)
+option(BUILD_SHARED_LIBS "Build shared libraries." OFF)
+
 if(CMAKE_COMPILER_IS_GNUCXX)
 	set(CMAKE_C_FLAGS "-std=c99")
 endif()
@@ -26,7 +29,11 @@ list(APPEND hdr
 	"utils/c11shim.h"
 	)
 
-set(libtype STATIC)
+if(BUILD_SHARED_LIBS)
+	set(libtype SHARED)
+else()
+	set(libtype STATIC)
+endif()
 
 add_library(libkeccak ${libtype} ${src} ${public_hdrs} ${hdr})
 
@@ -38,3 +45,15 @@ set_target_properties(libkeccak PROPERTIES
 #	VERSION 0.6.0
 	PREFIX ""
 	LIBFILENAME "libkeccak")
+
+### TESTS
+if (KECCAK_BUILD_TESTS)
+	add_executable(test0-sha3 "tests/test0-sha3.c")
+	target_link_libraries(test0-sha3 libkeccak)
+
+	add_executable(test0-shake "tests/test0-shake.c")
+	target_link_libraries(test0-shake libkeccak)
+
+	add_executable(test-kats "tests/test-kats.c")
+	target_link_libraries(test-kats libkeccak)
+endif()

--- a/keccak/config.h
+++ b/keccak/config.h
@@ -1,11 +1,23 @@
 #ifndef KECCAK_CONFIG_H
 #define KECCAK_CONFIG_H
-#if !defined(__COMPCERT__) && !defined(__FRAMAC__)
+
+#if defined(_WIN32)
+#define MIN2(A, B) ((A < B) ? A : B)
+#define memset_s(DST, DESTSIZE, VAL, COUNT) memset(DST, VAL, MIN2(DESTSIZE, COUNT))
+#endif
+
+#if !defined(__COMPCERT__) && !defined(__FRAMAC__) && !defined(_MSC_VER)
 #define INLINE inline __attribute__((always_inline))
+#define KINLINE
+#elif defined(_MSC_VER)
+#define INLINE
 #define KINLINE
 #else
 #define INLINE inline
 #define KINLINE
 #endif  // !defined(__COMPCERT__) && !defined(__FRAMAC__)
-#define NO_LIBUTIL
+
+// as project wide in CMakeLists.txt
+//#define NO_LIBUTIL
+
 #endif  // KECCAK_CONFIG_H

--- a/keccak/constructions/sponge-helpers-impl.h
+++ b/keccak/constructions/sponge-helpers-impl.h
@@ -28,6 +28,8 @@
 */
 static INLINE int _sponge_init(register keccak_sponge* const restrict sponge,
                                register const size_t rate) {
+  size_t i;
+
   if (sponge == NULL) {
     return -2;
   }
@@ -53,7 +55,7 @@ static INLINE int _sponge_init(register keccak_sponge* const restrict sponge,
   sponge->flags = 0;
 
   //@ loop variant 24 - i;
-  for (size_t i = 0; i < 25; i++) {
+  for (i = 0; i < 25; i++) {
     //@ assert \valid(sponge->a + i);
     sponge->a[i] = 0;
   }

--- a/keccak/constructions/sponge-impl.h
+++ b/keccak/constructions/sponge-impl.h
@@ -11,9 +11,14 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if defined(_MSC_VER)
+#pragma warning(disable:4244)
+#endif
+
 static INLINE size_t _sponge_absorb_once(register keccak_sponge* const restrict sponge,
                                          register const uint8_t* const restrict in,
                                          register const size_t inlen) {
+  // conversion from 32 to 64 bits: generates warnings on MSC (4244)
   register size_t canabsorb = sponge->rate - sponge->absorbed;
   register uint8_t* state = ((uint8_t*)sponge->a) + sponge->absorbed;
 

--- a/keccak/constructions/sponge.h
+++ b/keccak/constructions/sponge.h
@@ -3,9 +3,16 @@
 
 #include <string.h>
 #include <stdlib.h>
-#include <stdalign.h>
 #include <stdint.h>
+
+#ifndef _MSC_VER
+#include <stdalign.h>
 #include <stdbool.h>
+#else
+#ifndef restrict
+#define restrict __restrict
+#endif
+#endif
 
 /* The sponge structure. API users must treat it as an opaque blob.
  *

--- a/keccak/constructions/sponge.h
+++ b/keccak/constructions/sponge.h
@@ -14,6 +14,11 @@
 #endif
 #endif
 
+// EXPORT because when building libkeccak this file's declarations must match keccak.h (visual c++ complains otherwise)
+#ifndef KECCAK_EXPORT
+#define KECCAK_EXPORT
+#endif
+
 /* The sponge structure. API users must treat it as an opaque blob.
  *
  * TODO: This may be an excessivly redundant structure. Directly
@@ -59,7 +64,7 @@ typedef struct sponge {
 static const size_t sponge_bytelen = 200;
 #define sponge_bytelen 200
 // for CompCert and other C99 tools
-
+KECCAK_EXPORT
 int keccak_sponge_init(register keccak_sponge* const restrict sponge,
                        register const size_t rate);
 /*@ assigns \nothing;
@@ -79,12 +84,14 @@ int keccak_sponge_checkinv(register const keccak_sponge* const sponge);
 /*@ requires sponge_invariant(sponge);
     ensures sponge_invariant(sponge);
 */
+KECCAK_EXPORT
 int keccak_sponge_absorb(register keccak_sponge* const restrict sponge,
                          register const uint8_t* const restrict in,
                          register const size_t inlen);
 /*@ requires sponge_invariant(sponge);
     ensures sponge_invariant(sponge);
 */
+KECCAK_EXPORT
 int keccak_sponge_squeeze(register keccak_sponge* const restrict sponge,
                           register uint8_t* const restrict out,
                           register const size_t outlen);

--- a/keccak/fips202/sha3.c
+++ b/keccak/fips202/sha3.c
@@ -25,8 +25,9 @@
     disjoint behaviors;
 */
 int sha3_224_init(register keccak_sponge* const restrict sponge) {
+  int err;
   checknull(sponge);
-  int err = _hash_init(sponge, 200 - (28 * 2), flag_sha3_224 ^ hash_absorbing);
+  err = _hash_init(sponge, 200 - (28 * 2), flag_sha3_224 ^ hash_absorbing);
   //@ assert err == 0;
   HANDLE_ERR;
   return err;
@@ -53,9 +54,10 @@ int sha3_224_init(register keccak_sponge* const restrict sponge) {
 int sha3_224_update(register keccak_sponge* const restrict sponge,
                   register const uint8_t* const restrict in,
                   register const size_t inlen) {
+  int err;
   checknull(sponge);
   checknull(in);
-  int err = _hash_update(sponge, in, inlen, flag_sha3_224 ^ hash_absorbing);
+  err = _hash_update(sponge, in, inlen, flag_sha3_224 ^ hash_absorbing);
   //@assert err == 0;
   HANDLE_ERR;
   return err;
@@ -130,15 +132,17 @@ int sha3_224(register uint8_t* const restrict out,
     SOFT_RTE(digestlen);
   }
 
-  keccak_sponge sponge;
-  err = sha3_224_init(&sponge);  //@ assert(err == 0);
-  HANDLE_ERR;
-  err = sha3_224_update(&sponge, in, inlen);  //@ assert(err == 0);
-  HANDLE_ERR;
-  err = sha3_224_digest(&sponge, out, outlen);  //@ assert(err == 0);
-  HANDLE_ERR;
-  state_scribble(&sponge);
-  return err;
+  {
+    keccak_sponge sponge;
+    err = sha3_224_init(&sponge);  //@ assert(err == 0);
+    HANDLE_ERR;
+    err = sha3_224_update(&sponge, in, inlen);  //@ assert(err == 0);
+    HANDLE_ERR;
+    err = sha3_224_digest(&sponge, out, outlen);  //@ assert(err == 0);
+    HANDLE_ERR;
+    state_scribble(&sponge);
+    return err;
+  }
 }
 
 
@@ -156,8 +160,9 @@ int sha3_224(register uint8_t* const restrict out,
     disjoint behaviors;
 */
 int sha3_256_init(register keccak_sponge* const restrict sponge) {
+  int err;
   checknull(sponge);
-  int err = _hash_init(sponge, 200 - (32 * 2), flag_sha3_256 ^ hash_absorbing);
+  err = _hash_init(sponge, 200 - (32 * 2), flag_sha3_256 ^ hash_absorbing);
   //@ assert err == 0;
   HANDLE_ERR;
   return err;
@@ -184,9 +189,10 @@ int sha3_256_init(register keccak_sponge* const restrict sponge) {
 int sha3_256_update(register keccak_sponge* const restrict sponge,
                   register const uint8_t* const restrict in,
                   register const size_t inlen) {
+  int err;
   checknull(sponge);
   checknull(in);
-  int err = _hash_update(sponge, in, inlen, flag_sha3_256 ^ hash_absorbing);
+  err = _hash_update(sponge, in, inlen, flag_sha3_256 ^ hash_absorbing);
   //@assert err == 0;
   HANDLE_ERR;
   return err;
@@ -261,14 +267,17 @@ int sha3_256(register uint8_t* const restrict out,
     SOFT_RTE(digestlen);
   }
 
-  keccak_sponge sponge;
-  err = sha3_256_init(&sponge);  //@ assert(err == 0);
-  HANDLE_ERR;
-  err = sha3_256_update(&sponge, in, inlen);  //@ assert(err == 0);
-  HANDLE_ERR;
-  err = sha3_256_digest(&sponge, out, outlen);  //@ assert(err == 0);
-  HANDLE_ERR;
-  state_scribble(&sponge);
+  {
+    keccak_sponge sponge;
+    err = sha3_256_init(&sponge);  //@ assert(err == 0);
+    HANDLE_ERR;
+    err = sha3_256_update(&sponge, in, inlen);  //@ assert(err == 0);
+    HANDLE_ERR;
+    err = sha3_256_digest(&sponge, out, outlen);  //@ assert(err == 0);
+    HANDLE_ERR;
+    state_scribble(&sponge);
+  }
+
   return err;
 }
 
@@ -287,8 +296,9 @@ int sha3_256(register uint8_t* const restrict out,
     disjoint behaviors;
 */
 int sha3_384_init(register keccak_sponge* const restrict sponge) {
+  int err;
   checknull(sponge);
-  int err = _hash_init(sponge, 200 - (48 * 2), flag_sha3_384 ^ hash_absorbing);
+  err = _hash_init(sponge, 200 - (48 * 2), flag_sha3_384 ^ hash_absorbing);
   //@ assert err == 0;
   HANDLE_ERR;
   return err;
@@ -315,9 +325,10 @@ int sha3_384_init(register keccak_sponge* const restrict sponge) {
 int sha3_384_update(register keccak_sponge* const restrict sponge,
                   register const uint8_t* const restrict in,
                   register const size_t inlen) {
+  int err;
   checknull(sponge);
   checknull(in);
-  int err = _hash_update(sponge, in, inlen, flag_sha3_384 ^ hash_absorbing);
+  err = _hash_update(sponge, in, inlen, flag_sha3_384 ^ hash_absorbing);
   //@assert err == 0;
   HANDLE_ERR;
   return err;
@@ -392,14 +403,17 @@ int sha3_384(register uint8_t* const restrict out,
     SOFT_RTE(digestlen);
   }
 
-  keccak_sponge sponge;
-  err = sha3_384_init(&sponge);  //@ assert(err == 0);
-  HANDLE_ERR;
-  err = sha3_384_update(&sponge, in, inlen);  //@ assert(err == 0);
-  HANDLE_ERR;
-  err = sha3_384_digest(&sponge, out, outlen);  //@ assert(err == 0);
-  HANDLE_ERR;
-  state_scribble(&sponge);
+  {
+    keccak_sponge sponge;
+    err = sha3_384_init(&sponge);  //@ assert(err == 0);
+    HANDLE_ERR;
+    err = sha3_384_update(&sponge, in, inlen);  //@ assert(err == 0);
+    HANDLE_ERR;
+    err = sha3_384_digest(&sponge, out, outlen);  //@ assert(err == 0);
+    HANDLE_ERR;
+    state_scribble(&sponge);
+  }
+
   return err;
 }
 
@@ -418,8 +432,9 @@ int sha3_384(register uint8_t* const restrict out,
     disjoint behaviors;
 */
 int sha3_512_init(register keccak_sponge* const restrict sponge) {
+  int err;
   checknull(sponge);
-  int err = _hash_init(sponge, 200 - (64 * 2), flag_sha3_512 ^ hash_absorbing);
+  err = _hash_init(sponge, 200 - (64 * 2), flag_sha3_512 ^ hash_absorbing);
   //@ assert err == 0;
   HANDLE_ERR;
   return err;
@@ -446,9 +461,10 @@ int sha3_512_init(register keccak_sponge* const restrict sponge) {
 int sha3_512_update(register keccak_sponge* const restrict sponge,
                   register const uint8_t* const restrict in,
                   register const size_t inlen) {
+  int err;
   checknull(sponge);
   checknull(in);
-  int err = _hash_update(sponge, in, inlen, flag_sha3_512 ^ hash_absorbing);
+  err = _hash_update(sponge, in, inlen, flag_sha3_512 ^ hash_absorbing);
   //@assert err == 0;
   HANDLE_ERR;
   return err;
@@ -523,14 +539,17 @@ int sha3_512(register uint8_t* const restrict out,
     SOFT_RTE(digestlen);
   }
 
-  keccak_sponge sponge;
-  err = sha3_512_init(&sponge);  //@ assert(err == 0);
-  HANDLE_ERR;
-  err = sha3_512_update(&sponge, in, inlen);  //@ assert(err == 0);
-  HANDLE_ERR;
-  err = sha3_512_digest(&sponge, out, outlen);  //@ assert(err == 0);
-  HANDLE_ERR;
-  state_scribble(&sponge);
+  {
+    keccak_sponge sponge;
+    err = sha3_512_init(&sponge);  //@ assert(err == 0);
+    HANDLE_ERR;
+    err = sha3_512_update(&sponge, in, inlen);  //@ assert(err == 0);
+    HANDLE_ERR;
+    err = sha3_512_digest(&sponge, out, outlen);  //@ assert(err == 0);
+    HANDLE_ERR;
+    state_scribble(&sponge);
+  }
+
   return err;
 }
 

--- a/keccak/keccak/keccakf.c
+++ b/keccak/keccak/keccakf.c
@@ -1,7 +1,10 @@
 #include "keccak/keccak/keccakf-1600.h"
 #include "libutil/libutil.h"
 
+#ifndef _MSC_VER
 #include <stdalign.h>
+#endif
+
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>

--- a/keccak/modes/hash/hash-impl.h
+++ b/keccak/modes/hash/hash-impl.h
@@ -39,6 +39,7 @@ static INLINE int _hash_finalize(register keccak_sponge* const restrict sponge,
                                  register const uint8_t lastbyte,
                                  register const uint64_t oldflags,
                                  register const uint64_t newflags) {
+  register uint8_t* state;
   int err = _sponge_checkinv(sponge);
   if (err != 0) {
     return err;
@@ -48,7 +49,7 @@ static INLINE int _hash_finalize(register keccak_sponge* const restrict sponge,
     SOFT_RTE(hash_flags);
   }
 
-  register uint8_t* state = (uint8_t*)sponge->a;
+  state = (uint8_t*)sponge->a;
 
   // Xor in the MBR padding end-bit.
 

--- a/keccak/tests/helpers-impl.h
+++ b/keccak/tests/helpers-impl.h
@@ -6,7 +6,15 @@
 #include <stdint.h>
 #include <string.h>
 
-static inline int checktest(const char* const restrict description,
+#ifndef _MSC_VER
+#define INLINE inline
+#define SIZE_T_FORMAT "%zu"
+#else
+#define INLINE __inline
+#define SIZE_T_FORMAT "%Iu"
+#endif
+
+static INLINE int checktest(const char* const restrict description,
                             const uint8_t* const restrict known_answer,
                             const uint8_t* const restrict result,
                             const size_t bytelen) {
@@ -24,15 +32,16 @@ static inline int checktest(const char* const restrict description,
   }
 }
 
-static inline void _printkat(const uint8_t* const restrict msg,
+static INLINE void _printkat(const uint8_t* const restrict msg,
                              const size_t msgbytelen,
                              const uint8_t* const restrict md,
                              const size_t mdlen,
                              const char* mdname) {
-  printf("Len = %zu\n", msgbytelen * 8);
+  size_t i;
+  printf("Len = "SIZE_T_FORMAT"\n", msgbytelen * 8);
   printf("Msg = ");
   if (msgbytelen != 0) {
-    for (size_t i = 0; i < msgbytelen; i++) {
+    for (i = 0; i < msgbytelen; i++) {
       printf("%02X", msg[i]);
     }
   } else {
@@ -41,7 +50,7 @@ static inline void _printkat(const uint8_t* const restrict msg,
   }
   printf("\n");
   printf("%s = ", mdname);
-  for (size_t i = 0; i < mdlen; i++) {
+  for (i = 0; i < mdlen; i++) {
     printf("%02X", md[i]);
   }
   printf("\n");

--- a/keccak/tests/test-sha3-impl.h
+++ b/keccak/tests/test-sha3-impl.h
@@ -13,7 +13,8 @@
   int test_sha3_##BITS(void) {                   \
     keccak_sponge sponge;                        \
     const uint8_t* inpos = in;                   \
-    for (size_t len = 0; len < 256; len++) {     \
+    size_t len; \
+    for (len = 0; len < 256; len++) {            \
       uint8_t out[BYTES] = {0};                  \
       uint8_t outs[BYTES] = {0};                 \
                                                  \

--- a/keccak/tests/test-shake-impl.h
+++ b/keccak/tests/test-shake-impl.h
@@ -11,9 +11,10 @@
 #define TEST(BITS, BYTES)                        \
   int test_shake##BITS(void);                    \
   int test_shake##BITS(void) {                   \
+    size_t len;                                  \
     keccak_sponge sponge;                        \
     const uint8_t* inpos = in;                   \
-    for (size_t len = 0; len < 256; len++) {     \
+    for (len = 0; len < 256; len++) {            \
       uint8_t out[BYTES] = {0};                  \
       uint8_t outs[BYTES] = {0};                 \
                                                  \

--- a/keccak/utils/xorinto-impl.h
+++ b/keccak/utils/xorinto-impl.h
@@ -5,12 +5,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#ifndef _MSC_VER
+#define ALWAYS_INLINE __attribute__((always_inline))
+#else
+#define ALWAYS_INLINE __inline
+#endif
+
 /* requires \valid(dest+(0..oplen-1)) && \valid_read(in+(0..oplen-1));
     assigns dest[0..oplen-1];
   */
-static __attribute__((always_inline)) int _xorinto(uint8_t* const restrict dest,
+static ALWAYS_INLINE int _xorinto(uint8_t* const restrict dest,
                            const uint8_t* const restrict in,
                            const size_t oplen) {
+  size_t i;
   switch (oplen) {
 #ifndef __FRAMAC__
 #include "keccak/utils/xorinto-unrolled.gen.h"
@@ -18,7 +25,7 @@ static __attribute__((always_inline)) int _xorinto(uint8_t* const restrict dest,
     //#endif
     default:
       //@ loop variant oplen - i;
-      for (size_t i = 0; i < oplen; i++) {
+      for (i = 0; i < oplen; i++) {
         //@ assert i < oplen;
         dest[i] = dest[i] ^ in[i];
       }

--- a/libutil/libutil.h
+++ b/libutil/libutil.h
@@ -1,11 +1,19 @@
 #ifndef UTILS_LIBUTIL_H
 #define UTILS_LIBUTIL_H
+
 #include <stdlib.h>
 #ifndef NO_LIBUTIL
 extern void memclear(void* const, const size_t);
 extern void state_scribble(void* const);
 extern void state_clear(void* const);
 extern uint64_t cpucycles(void);
+#elif defined(_MSC_VER)
+#include <intrin.h>
+#pragma intrinsic(__rdtsc)
+#define memclear(DST, LEN) memset((DST), 0, (LEN))
+#define state_scribble(A) memset((A), 0xc1, 200)
+#define state_clear(A) memset((A), 0, 200)
+#define cpucycles() __rdtsc()
 #else
 #include <string.h>
 #define memclear(DST, LEN) memset_s((DST), (LEN), 0, (LEN))
@@ -13,4 +21,5 @@ extern uint64_t cpucycles(void);
 #define state_clear(A) memset_s((A), 200, 0, 200)
 #define cpucycles() __builtin_readcyclecounter()
 #endif  // NO_LIBUTIL
+
 #endif  // UTILS_LIBUTIL_H


### PR DESCRIPTION
- improved main cmake lists file and keccak cmake lists file
- changed cmake minimum version to 2.8 as 3.0 isn't required
- defined restrict on VC++ to be __restrict
- added export keyword to public interface functions (windows only)
- the library now compiles with visual c++ and mingw (tested with visual studio 2012)
- changed memset_s to be memset on WIN32
- changed lot of code to be less c99 so that the c compiler part of visual c++ can compile it
- disabled VC++ warning 4244
- vc++: removed what appears to be unused headers (stdalign.h, stdbool.h)
- using __inline on VC++ (static inline fails)
- added header location as interface directory (nice for dependent libraries using cmake)
- defined `NO_LIBUTIL` in cmake instead of config.h
- export all functions from keccak.h
- add cmake options for building the library tests (`KECCAK_BUILD_TESTS` default yes) and to switch from STATIC to SHARED library build (`BUILD_SHARED_LIBS` default no)
- fixed `test0-sha3`, `test0-shake` and `test-kats` to compile and run under visual c++ 32 and 64 bits
